### PR TITLE
Change Spotify client key to be retrieved from env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/src/api.js
+++ b/src/api.js
@@ -1,8 +1,12 @@
 import axios from 'axios';
 
 const getToken = async () => {
+  const spotifyClientKey = 
+    process.env.REACT_APP_SPOTIFY_CLIENT_ID +
+    ':' +
+    process.env.REACT_APP_SPOTIFY_CLIENT_SECRET;
   const params = 'grant_type=client_credentials';
-  const encodedString = new Buffer('7c0b9ed0ae194c888450394069d7cb59:81177d6e289e424c84ce9a21a8b2f775').toString('base64');
+  const encodedString = new Buffer(spotifyClientKey).toString('base64');
   const headers = {
     headers: {
       'Authorization': `Basic ${encodedString}`,


### PR DESCRIPTION
As explained in the linked issue:

```
This just helps to not have them in the code, but in runtime they can be seen! Not a solution for a deployable app.

Justification of the above:
https://stackoverflow.com/a/46839021/15510462

Use env vars with create-react-app:
https://stackoverflow.com/a/50457996/15510462
```